### PR TITLE
Improve Services Definition

### DIFF
--- a/custom_components/simple_inventory/services.yaml
+++ b/custom_components/simple_inventory/services.yaml
@@ -5,65 +5,95 @@ add_item:
       description: ID of the inventory to add to
       example: "01JYFPCDMBRBRK4MB3C26S2FKH"
       required: true
+      selector:
+        text:
     name:
       description: Name of the item
       example: "Frozen Pizza"
       required: true
+      selector:
+        text:
     quantity:
       description: Quantity of the item
       example: 2
       required: false
       default: 1
+      selector:
+        number:
+          min: 0
     unit:
       description: Unit of measurement
       example: "boxes"
       required: false
       default: ""
+      selector:
+        text:
     category:
       description: Category of the item
       example: "Prepared Foods"
       required: false
       default: ""
+      selector:
+        text:
     expiry_date:
       description: Expiration date
       example: "2025-12-31"
       required: false
       default: ""
+      selector:
+        date:
     expiry_alert_days:
       description: Number of days in advance to warn about expiring items
       example: 7
       required: false
       default: 0
+      selector:
+        number:
+          min: 0
     auto_add_enabled:
       description: Enable automatic adding to todo list
       example: true
       required: false
       default: false
+      selector:
+        boolean:
     auto_add_to_list_quantity:
       description: Quantity threshold for auto-adding
       example: 1
       required: false
       default: 0
+      selector:
+        number:
+          min: 0
     todo_list:
       description: Todo list entity to add to
       example: "todo.grocery_list"
       required: false
       default: ""
+      selector:
+        entity:
+          domain: todo
     location:
       description: Location of the item
       example: Basement Refrigerator
       required: false
       default: ""
+      selector:
+        text:
     description:
       description: Item description
       example: "Junk food"
       required: false
       default: ""
+      selector:
+        text:
     auto_add_id_to_description_enabled:
       description: Appends the inventory ID to the description
-      example: 1
+      example: true
       required: false
-      default: 0
+      default: false
+      selector:
+        boolean:
 
 remove_item:
   description: Remove an item from an inventory
@@ -72,10 +102,14 @@ remove_item:
       description: ID of the inventory to remove from
       example: "01JYFPCDMBRBRK4MB3C26S2FKH"
       required: true
+      selector:
+        text:
     name:
       description: Name of the item to remove
       example: "Frozen Pizza"
       required: true
+      selector:
+        text:
 
 increment_item:
   description: Increment the quantity of an item
@@ -84,15 +118,22 @@ increment_item:
       description: ID of the inventory
       example: "01JYFPCDMBRBRK4MB3C26S2FKH"
       required: true
+      selector:
+        text:
     name:
       description: Name of the item
       example: "Frozen Pizza"
       required: true
+      selector:
+        text:
     amount:
       description: Amount to increment by
       example: 1
       required: false
       default: 1
+      selector:
+        number:
+          min: 1
 
 decrement_item:
   description: Decrement the quantity of an item
@@ -101,15 +142,22 @@ decrement_item:
       description: ID of the inventory
       example: "01JYFPCDMBRBRK4MB3C26S2FKH"
       required: true
+      selector:
+        text:
     name:
       description: Name of the item
       example: "Frozen Pizza"
       required: true
+      selector:
+        text:
     amount:
       description: Amount to decrement by
       example: 1
       required: false
       default: 1
+      selector:
+        number:
+          min: 1
 
 update_item:
   description: Update an existing inventory item
@@ -118,61 +166,91 @@ update_item:
       description: ID of the inventory
       example: "01JYFPCDMBRBRK4MB3C26S2FKH"
       required: true
+      selector:
+        text:
     old_name:
       description: Current name of the item
       example: "Old Item Name"
       required: true
+      selector:
+        text:
     name:
       description: New name of the item
       example: "New Item Name"
       required: true
+      selector:
+        text:
     quantity:
       description: New quantity
       example: 5
       required: false
+      selector:
+        number:
+          min: 0
     unit:
       description: Unit of measurement
       example: "boxes"
       required: false
+      selector:
+        text:
     category:
       description: Category
       example: "Frozen Foods"
       required: false
+      selector:
+        text:
     expiry_date:
       description: Expiration date
       example: "2025-12-31"
       required: false
+      selector:
+        date:
     auto_add_enabled:
       description: Enable auto-add to todo list
       example: true
       required: false
+      selector:
+        boolean:
     auto_add_to_list_quantity:
       description: Threshold for auto-add
       example: 1
       required: false
+      selector:
+        number:
+          min: 0
     todo_list:
       description: Todo list entity
       example: "todo.grocery_list"
       required: false
+      selector:
+        entity:
+          domain: todo
     expiry_alert_days:
       description: Number of days in advance to warn about expiring items
       example: 7
       required: false
+      selector:
+        number:
+          min: 0
     location:
       description: Location of the item
       example: Basement Refrigerator
       required: false
-      default: ""
+      selector:
+        text:
     description:
       description: Item description
       example: "Junk food"
       required: false
-      default: ""
+      selector:
+        text:
     auto_add_id_to_description_enabled:
       description: Appends the inventory ID to the description
-      example: 1
+      example: true
       required: false
-      default: 0
+      selector:
+        boolean:
+
 
 get_items:
   description: Return the full list of items for an inventory. Use return_response. Can specify either inventory_id or inventory_name (but not both).
@@ -181,10 +259,14 @@ get_items:
       description: ID of the inventory
       example: "01JYFPCDMBRBRK4MB3C26S2FKH"
       required: false
+      selector:
+        text:
     inventory_name:
       description: Name of the inventory (case-insensitive)
       example: "Kitchen Freezer"
       required: false
+      selector:
+        text:
 
 get_items_from_all_inventories:
   description: Return the full list of items grouped by inventory. Use return_response.


### PR DESCRIPTION
When trying the services/actions in the Developer tab or maintaining them in an automation, only YAML is available for the payload. This PR aims at improving the UX here:

- Add `selectors` definitions: Now, every field is available for editing via UI
- Remove defaults for update service call: If set, you would explicitly need to unselect these fields to avoid sending the defaults.
- Change default and example for auto add inventory id to boolean values instead of `0`/`1`: The type is defined as boolean in types and the service call accepts `true`/`false` as value. Furthermore, `0`/`1` could also be a number instead of a boolean.